### PR TITLE
Patches following 1.0.0 release

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -27,15 +27,15 @@ polymerization mechanism, and any co-molecules (e.g. solvent) you wish to model.
 * 2.3 - `Solvation and packing of polymer melts <https://github.com/timbernat/polymerist_examples/blob/main/2-preparation/2.3-melt_packing_and_solvation.ipynb>`_
 * 2.4 - `Reduction Charge Transfer (RCT) for generating custom library charges <https://github.com/timbernat/polymerist_examples/blob/main/2-preparation/2.4-RCT_demo.ipynb>`_
 
-3 - `Running polymer simulations <https://github.com/timbernat/polymerist_examples/blob/main/3-simulation/3.0-index.ipynb>`_
+3 - `Running polymer simulations <https://github.com/timbernat/polymerist_examples/blob/main/3-workflows/3.0-index.ipynb>`_
 ============================================================================================================================
-* 3.1 - `Exporting polymer systems to common MD engines <https://github.com/timbernat/polymerist_examples/blob/main/3-simulation/3.1-MD_export_with_Interchange.ipynb>`_
-* 3.2 - `Reproducibly serializing OpenMM simulations <https://github.com/timbernat/polymerist_examples/blob/main/3-simulation/3.2-serializable_simulation_parameters.ipynb>`_
-* 3.3 - `Running series of OpenMM simulations <https://github.com/timbernat/polymerist_examples/blob/main/3-simulation/3.3-running_openmm_simulations.ipynb>`_
-* 3.4 - `A start-to-finish polymer simulation workflow <https://github.com/timbernat/polymerist_examples/blob/main/3-simulation/3.4-full_workflow_demo.ipynb>`_
+* 3.1 - `Exporting polymer systems to common MD engines <https://github.com/timbernat/polymerist_examples/blob/main/3-workflows/3.1-MD_export_with_Interchange.ipynb>`_
+* 3.2 - `Reproducibly serializing OpenMM simulations <https://github.com/timbernat/polymerist_examples/blob/main/3-workflows/3.2-serializable_simulation_parameters.ipynb>`_
+* 3.3 - `Running series of OpenMM simulations <https://github.com/timbernat/polymerist_examples/blob/main/3-workflows/3.3-running_openmm_simulations.ipynb>`_
+* 3.4 - `A start-to-finish polymer simulation workflow <https://github.com/timbernat/polymerist_examples/blob/main/3-workflows/3.4-full_workflow_demo.ipynb>`_
 
-`Miscellaneous <https://github.com/timbernat/polymerist_examples/blob/main/4-misc/4.0-index.ipynb>`_
+`Miscellaneous <https://github.com/timbernat/polymerist_examples/blob/main/4-miscellaneous/>`_
 ====================================================================================================
-* `Exporting arbitrary Python objects to JSON <https://github.com/timbernat/polymerist_examples/blob/main/4-miscellanous/jsonification.ipynb>`_
-* `Automated ring piercing detection (PINPRICS) <https://github.com/timbernat/polymerist_examples/blob/main/4-miscellanous/ring-piercing.ipynb>`_
-* `Loading boron-containing molecules into OpenFF <https://github.com/timbernat/polymerist_examples/blob/main/4-miscellanous/openff_boron_demo.py>`_
+* `Exporting arbitrary Python objects to JSON <https://github.com/timbernat/polymerist_examples/blob/main/4-miscellaneous/jsonification.ipynb>`_
+* `Automated ring piercing detection (PINPRICS) <https://github.com/timbernat/polymerist_examples/blob/main/4-miscellaneous/ring-piercing.ipynb>`_
+* `Loading boron-containing molecules into OpenFF <https://github.com/timbernat/polymerist_examples/blob/main/4-miscellaneous/openff_boron_demo.py>`_

--- a/polymerist/genutils/importutils/pkgiter.py
+++ b/polymerist/genutils/importutils/pkgiter.py
@@ -7,7 +7,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 from types import ModuleType
-from typing import Generator, Iterable, Optional, Union
+from typing import Container, Generator, Iterable, Optional, Union
 
 from importlib import import_module
 from pkgutil import iter_modules as _iter_modules
@@ -38,7 +38,8 @@ class ModuleToNodeCorrespondence(NodeCorrespondence, FROMTYPE=ModuleType):
             try:
                 submodule = import_module(module_name)
                 yield submodule
-            except (ModuleNotFoundError, MissingPrerequisitePackage):
+            except (ImportError, ModuleNotFoundError, MissingPrerequisitePackage) as module_error:
+                LOGGER.error(f'Failed to import submodule {module_name} due to {type(module_error).__name__}: "{module_error}"')
                 continue
 
 module_tree = compile_tree_factory(
@@ -49,7 +50,11 @@ module_tree = compile_tree_factory(
 )
 
 # BACKWARDS-COMPATIBLE PORTS OF LEGACY IMPORTUTILS FUNCTIONS
-def module_tree_direct(module : ModuleType, recursive : bool=True, blacklist : Optional[Iterable[str]]=None) -> Node:
+def module_tree_direct(
+        module : ModuleType,
+        recursive : bool=True,
+        blacklist : Optional[Container[str]]=None,
+    ) -> Node:
     '''Produce a tree from the Python package hierarchy starting with a given module
     
     Parameters
@@ -59,7 +64,7 @@ def module_tree_direct(module : ModuleType, recursive : bool=True, blacklist : O
         Represented in the Node object returned by this function
     recursive : bool, default=True
         Whether or not to recursively import modules from subpackages and add them to the tree
-    blacklist : list[str] (optional), default None
+    blacklist : Container[str] (optional)
         List of module names to exclude from tree building
         If provided, will exclude any modules whose names occur in this list
 
@@ -77,7 +82,11 @@ def module_tree_direct(module : ModuleType, recursive : bool=True, blacklist : O
         exclude=lambda module : module_stem(module) in blacklist,
     )
 
-def iter_submodules(module : ModuleType, recursive : bool=True, blacklist : Optional[Iterable[str]]=None) -> Generator[ModuleType, None, None]:
+def iter_submodules(
+        module : ModuleType,
+        recursive : bool=True,
+        blacklist : Optional[Container[str]]=None,
+    ) -> Generator[ModuleType, None, None]:
     '''
     Generates all modules which can be imported from the given toplevel module
     
@@ -88,7 +97,7 @@ def iter_submodules(module : ModuleType, recursive : bool=True, blacklist : Opti
         Represented in the Node object returned by this function
     recursive : bool, default=True
         Whether or not to recursively import modules from subpackages and add them to the tree
-    blacklist : list[str] (optional), default None
+    blacklist : Container[str] (optional)
         List of module names to exclude from tree building
         If provided, will exclude any modules whose names occur in this list
 
@@ -101,7 +110,11 @@ def iter_submodules(module : ModuleType, recursive : bool=True, blacklist : Opti
     for module_node in PreOrderIter(modtree):
         yield module_node.module
 
-def iter_submodule_info(module : ModuleType, recursive : bool=True, blacklist : Optional[Iterable[str]]=None) -> Generator[tuple[ModuleType, str, bool], None, None]:
+def iter_submodule_info(
+        module : ModuleType,
+        recursive : bool=True,
+        blacklist : Optional[Container[str]]=None,
+    ) -> Generator[tuple[ModuleType, str, bool], None, None]:
     '''
     Generates information about all modules which can be imported from the given toplevel module
     Namely, yields the module object, module name, and whether or not the module is a package
@@ -113,7 +126,7 @@ def iter_submodule_info(module : ModuleType, recursive : bool=True, blacklist : 
         Represented in the Node object returned by this function
     recursive : bool, default=True
         Whether or not to recursively import modules from subpackages and add them to the tree
-    blacklist : list[str] (optional), default None
+    blacklist : Container[str] (optional)
         List of module names to exclude from tree building
         If provided, will exclude any modules whose names occur in this list
 
@@ -127,7 +140,11 @@ def iter_submodule_info(module : ModuleType, recursive : bool=True, blacklist : 
     for module_node in PreOrderIter(modtree):
         yield module_node.module, module_node.name, module_node.is_leaf
 
-def register_submodules(module : ModuleType, recursive : bool=True, blacklist : Optional[Iterable[str]]=None) -> None:
+def register_submodules(
+        module : ModuleType,
+        recursive : bool=True,
+        blacklist : Optional[Container[str]]=None
+    ) -> None:
     '''
     Registers all submodules of a given module into it's own namespace (i.e. autoimports submodules)
     
@@ -138,7 +155,7 @@ def register_submodules(module : ModuleType, recursive : bool=True, blacklist : 
         Represented in the Node object returned by this function
     recursive : bool, default=True
         Whether or not to recursively import modules from subpackages and add them to the tree
-    blacklist : list[str] (optional), default None
+    blacklist : Container[str] (optional)
         List of module names to exclude from tree building
         If provided, will exclude any modules whose names occur in this list
 
@@ -149,7 +166,12 @@ def register_submodules(module : ModuleType, recursive : bool=True, blacklist : 
     for submodule in iter_submodules(module, recursive=recursive, blacklist=blacklist):
         setattr(module, submodule.__name__, submodule)
 
-def module_hierarchy(module : ModuleType, recursive : bool=True, blacklist : Optional[Iterable[str]]=None, style : Union[str, AbstractStyle]=ContStyle()) -> str:
+def module_hierarchy(
+        module : ModuleType,
+        recursive : bool=True,
+        blacklist : Optional[Container[str]]=None,
+        style : Union[str, AbstractStyle]=ContStyle()
+    ) -> str:
     '''
     Generates a printable string which summarizes a Python packages hierarchy. Reminiscent of GNU tree output
 
@@ -160,7 +182,7 @@ def module_hierarchy(module : ModuleType, recursive : bool=True, blacklist : Opt
         Represented in the Node object returned by this function
     recursive : bool, default=True
         Whether or not to recursively import modules from subpackages and add them to the tree
-    blacklist : list[str] (optional), default None
+    blacklist : Container[str] (optional)
         List of module names to exclude from tree building
         If provided, will exclude any modules whose names occur in this list
     style : str or AbstractStyle


### PR DESCRIPTION
## Description
Fix small bugs in code and docs found after putting out 1.0.0 release

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Fix broken links and typos in example docs
  - [ ] Fixed bug where
  - [ ] Improve typing and robustness of importutils.pkgiter module trees
    - [ ] Added explicit Error + logging for ImportError
    - [ ] Fixed typehint on "blacklist" arg (from List to Container)
  - [ ] Ideally fix erroneous install of rdutils.rdconvert (deprecated on 2025/01/31 but still shipped w/ pip install for some reason)

## Status
- [ ] Pass tests
- [ ] Ready to go