### PR TITLE
Proposal to make middle monomer assignment in build_linear_polymer() adhere to strict alphabetical order

### DIFF
--- a/polymerist/polymers/building/linear.py
+++ b/polymerist/polymers/building/linear.py
@@ -98,11 +98,18 @@ def build_linear_polymer(
     monomers_selected = MonomerGroup() # used to track and estimate sized of the monomers being used for building
     
     ## 2A) ADD MIDDLE MONOMERS TO CHAIN
-    for symbol, (resname, middle_monomer) in zip(sequence_unique, monomers.iter_rdmols(term_only=False)): # zip with sequence limits number of middle monomers to length of block sequence
-        LOGGER.info(f'Registering middle monomer {resname} (block identifier "{symbol}")')
+    monomer_list = list(monomers.iter_rdmols(term_only=False))
+    
+    for symbol in sequence_unique:
+        # Convert symbol (A, B, C, ...) to index (0, 1, 2, ...)
+        idx = ord(symbol) - ord("A")
+        resname, middle_monomer = monomer_list[idx]
+    
+        LOGGER.info(f'Registering middle monomer {resname} (block identifier \"{symbol}\")')
         mb_monomer, linker_ids = mbmol_from_mono_rdmol(middle_monomer, resname=resname)
         polymer.add_monomer(compound=mb_monomer, indices=linker_ids)
         monomers_selected.monomers[resname] = monomers.monomers[resname]
+
 
     ## 2B) ADD TERMINAL MONOMERS TO CHAIN
     for head_or_tail, (resname, term_monomer) in end_groups.items():


### PR DESCRIPTION
## Description
~~Previous implementation assumes that the provided sequence string will be "A" -> "Z" with no gaps.~~ _Not the case, and nowhere indicated to be such_
This allows one to index naievely into the list returned by monogrp.iter_rdmols(term_only=False). 

~~This breaks if a user passes a discontinuous string, such as "ACDE". C will be incorrectly mapped to the second monomer, and the off-by-one error will propagate.~~
_Some users may expect the index of characters in the sequence to correspond to their position in the alphabet, rather than their order (as implemented by the wrapped [Polymer recipe from mbuild](https://github.com/mosdef-hub/mbuild/blob/main/mbuild/lib/recipes/polymer.py#L166-L175))_

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] ~~fixes erroneous monomer extraction  from monomers.iter_rdmols()~~ Imposes strictly-alphabetical indexing on middle repeat units registered during linear polymer build

## Questions
- [ ] 

## Status
- [ ] Ready to go