### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest] #, windows-latest] # AmberTools is not currently installable on Windows
-        python-version: ["3.11"] #, "3.12"] # intend to support more recent Python version eventually, but tooling is built around 3.11 only for now
+        python-version: ["3.11", "3.12"] # intend to support more recent Python version eventually, but tooling is built around 3.11 only for now
       fail-fast: false
 
     steps:

--- a/devtools/conda-envs/dev-build.yml
+++ b/devtools/conda-envs/dev-build.yml
@@ -95,7 +95,6 @@ dependencies:
   - docutils=0.21.2=pyhd8ed1ab_1
   - double-conversion=3.3.1=h5888daf_0
   - ele=0.2.0=pyhd8ed1ab_0
-  - espaloma_charge=0.0.8=pyhd8ed1ab_3
   - exceptiongroup=1.3.0=pyhd8ed1ab_0
   - executing=2.2.0=pyhd8ed1ab_0
   - expat=2.7.1=hecca717_0

--- a/devtools/conda-envs/docs-env.yml
+++ b/devtools/conda-envs/docs-env.yml
@@ -50,9 +50,6 @@ dependencies:
     - openff-nagl>=0.5
     - openff-nagl-models>=0.3
 
-    # Espaloma
-    - espaloma_charge>=0.0.8
-
     # Chemical database queries
     - cirpy
     - pubchempy

--- a/devtools/conda-envs/docs-env.yml
+++ b/devtools/conda-envs/docs-env.yml
@@ -33,9 +33,10 @@ dependencies:
 
     # Molecule building
     - rdkit
-    - mbuild
+    - mbuild>=1.0
     - openbabel
-    - packmol<=20.15.1 # DEVNOTE: have no idea why, but versions tested later than this release (at least 20.16.1 and 21.0.4) introduce PDB CONECT errors where there were previously none
+    # - packmol<=20.15.1 # DEVNOTE: have no idea why, but versions tested later than this release (at least 20.16.1 and 21.0.4) introduce PDB CONECT errors where there were previously none
+    - packmol
     - openeye-toolkits # TODO: consider making this optional?
 
     # MD engines

--- a/devtools/conda-envs/docs-env.yml
+++ b/devtools/conda-envs/docs-env.yml
@@ -13,7 +13,7 @@ dependencies:
     - pytest-cov
     - codecov
 
-   # Docs
+    # Docs
     - sphinx
     - sphinx-autoapi
     - sphinx_rtd_theme

--- a/devtools/conda-envs/docs-env.yml
+++ b/devtools/conda-envs/docs-env.yml
@@ -6,6 +6,7 @@ dependencies:
     # Basic Python dependencies
     - python>=3.11
     - pip
+    - setuptools<82 # to avoid ImportErrors from pkg_resources deprecation
 
     # Unit testing
     - pytest

--- a/devtools/conda-envs/docs-env.yml
+++ b/devtools/conda-envs/docs-env.yml
@@ -40,7 +40,7 @@ dependencies:
 
     # MD engines
     - openmm
-    - lammps # DEV: keep an eye on this as updates roll out - 2024.08.29 is latest STABLE version at time of writing this comment (08/18/25)
+    - lammps<=2024.08.29 # DEV: keep an eye on this as updates roll out - 2024.08.29 is latest STABLE version at time of writing this comment (08/18/25)
     - mdtraj
     - pint # for units in case OpenFF is not installed
 

--- a/devtools/conda-envs/docs-env.yml
+++ b/devtools/conda-envs/docs-env.yml
@@ -4,7 +4,7 @@ channels:
     - openeye
 dependencies:
     # Basic Python dependencies
-    - python=3.11.0
+    - python>=3.11
     - pip
 
     # Unit testing

--- a/devtools/conda-envs/release-build.yml
+++ b/devtools/conda-envs/release-build.yml
@@ -13,10 +13,6 @@ dependencies:
     - pytest-cov
     - codecov
 
-   # Docs
-    - sphinx
-    - sphinx_rtd_theme
-
     # Numerical libraries
     - numpy
     - pandas

--- a/devtools/conda-envs/release-build.yml
+++ b/devtools/conda-envs/release-build.yml
@@ -50,9 +50,6 @@ dependencies:
     - openff-nagl>=0.5
     - openff-nagl-models>=0.3
 
-    # Espaloma
-    - espaloma_charge>=0.0.8
-
     # Chemical database queries
     - cirpy
     - pubchempy

--- a/devtools/conda-envs/release-build.yml
+++ b/devtools/conda-envs/release-build.yml
@@ -6,7 +6,7 @@ dependencies:
     # Basic Python dependencies
     - python>=3.11.0
     - pip
-    - setuptools
+    - setuptools<82 # to avoid ImportErrors from pkg_resources deprecation
 
     # Unit testing
     - pytest

--- a/devtools/conda-envs/release-build.yml
+++ b/devtools/conda-envs/release-build.yml
@@ -4,9 +4,9 @@ channels:
     - openeye
 dependencies:
     # Basic Python dependencies
-    - python=3.11.0
+    - python>=3.11.0
     - pip
-    - setuptools<82 # to avoid ImportErrors from pkg_resources deprecation
+    - setuptools
 
     # Unit testing
     - pytest
@@ -35,7 +35,7 @@ dependencies:
     - rdkit
     - mbuild
     - openbabel
-    - packmol<=20.15.1 # DEVNOTE: have no idea why, but versions tested later than this release (at least 20.16.1 and 21.0.4) introduce PDB CONECT errors where there were previously none
+    - packmol
     - openeye-toolkits # TODO: consider making this optional?
 
     # MD engines

--- a/devtools/conda-envs/release-build.yml
+++ b/devtools/conda-envs/release-build.yml
@@ -40,7 +40,7 @@ dependencies:
 
     # MD engines
     - openmm
-    - lammps # DEV: keep an eye on this as updates roll out - 2024.08.29 is latest STABLE version at time of writing this comment (08/18/25)
+    - lammps<=2024.08.29 # DEV: keep an eye on this as updates roll out - 2024.08.29 is latest STABLE version at time of writing this comment (08/18/25)
     - mdtraj
     - pint # for units in case OpenFF is not installed
 

--- a/devtools/conda-envs/release-build.yml
+++ b/devtools/conda-envs/release-build.yml
@@ -33,7 +33,7 @@ dependencies:
 
     # Molecule building
     - rdkit
-    - mbuild
+    - mbuild>=1.0
     - openbabel
     - packmol
     - openeye-toolkits # TODO: consider making this optional?

--- a/devtools/conda-envs/test-env.yml
+++ b/devtools/conda-envs/test-env.yml
@@ -34,7 +34,7 @@ dependencies:
 
     # MD engines
     - openmm
-    - lammps # DEV: keep an eye on this as updates roll out - 2024.08.29 is latest STABLE version at time of writing this comment (08/18/25)
+    - lammps<=2024.08.29 # DEV: keep an eye on this as updates roll out - 2024.08.29 is latest STABLE version at time of writing this comment (08/18/25)
     - mdtraj
     - pint # for units in case OpenFF is not installed
 

--- a/devtools/conda-envs/test-env.yml
+++ b/devtools/conda-envs/test-env.yml
@@ -26,7 +26,7 @@ dependencies:
 
     # Molecule building
     - rdkit
-    - mbuild
+    - mbuild>=1.0
     - openbabel
     # - packmol<=20.15.1 # DEVNOTE: have no idea why, but versions tested later than this release (at least 20.16.1 and 21.0.4) introduce PDB CONECT errors where there were previously none
     - packmol

--- a/devtools/conda-envs/test-env.yml
+++ b/devtools/conda-envs/test-env.yml
@@ -4,9 +4,9 @@ channels:
     - openeye
 dependencies:
     # Basic Python dependencies
-    - python=3.11.0
+    - python>=3.11.0
     - pip
-    - setuptools<82 # to avoid ImportErrors from pkg_resources deprecation
+    - setuptools
 
     # Unit testing
     - pytest
@@ -28,7 +28,8 @@ dependencies:
     - rdkit
     - mbuild
     - openbabel
-    - packmol<=20.15.1 # DEVNOTE: have no idea why, but versions tested later than this release (at least 20.16.1 and 21.0.4) introduce PDB CONECT errors where there were previously none
+    # - packmol<=20.15.1 # DEVNOTE: have no idea why, but versions tested later than this release (at least 20.16.1 and 21.0.4) introduce PDB CONECT errors where there were previously none
+    - packmol
     - openeye-toolkits # TODO: consider making this optional?
 
     # MD engines

--- a/devtools/conda-envs/test-env.yml
+++ b/devtools/conda-envs/test-env.yml
@@ -45,7 +45,7 @@ dependencies:
     - openff-nagl-models>=0.3
 
     # Espaloma
-    - espaloma_charge>=0.0.8
+    # - espaloma_charge>=0.0.8
 
     # Chemical database queries
     - cirpy

--- a/devtools/conda-envs/test-env.yml
+++ b/devtools/conda-envs/test-env.yml
@@ -6,7 +6,7 @@ dependencies:
     # Basic Python dependencies
     - python>=3.11.0
     - pip
-    - setuptools
+    - setuptools<82 # to avoid ImportErrors from pkg_resources deprecation
 
     # Unit testing
     - pytest

--- a/devtools/conda-envs/test-env.yml
+++ b/devtools/conda-envs/test-env.yml
@@ -13,16 +13,21 @@ dependencies:
     - pytest-cov
     - nbval
 
-    # Visualization (needed for automated notebook tests)
-    - jupyterlab
-    - py3Dmol
-    - nglview==3.0.6
+    # Docs
+    - sphinx
+    - sphinx-autoapi
+    - sphinx_rtd_theme
 
     # Numerical libraries
     - numpy
     - pandas
     - networkx
     - anytree
+
+    # Visualization (needed for automated notebook tests)
+    - jupyterlab
+    - py3Dmol
+    - nglview==3.0.6
 
     # Molecule building
     - rdkit

--- a/polymerist/genutils/importutils/pkginspect.py
+++ b/polymerist/genutils/importutils/pkginspect.py
@@ -11,29 +11,36 @@ from importlib.resources import (
     Package,
     files as get_package_path
 )
-from importlib.resources._common import get_package, from_package, resolve
+from importlib.resources._common import resolve
+
+ModuleLike = Union[str, ModuleType, Package]
 
 
 # CHECKING PACKAGE AND MODULE STATUS
-def is_module(module : Package) -> bool:
+def is_module(module : ModuleLike) -> bool:
     '''Determine whether a given Package-like (i.e. str or ModuleType) is a valid Python module
     This will return True for packages, bottom-level modules (i.e. *.py) and Python scripts'''
     try:
-        resolve(module)
-        return True
+        module_loaded : ModuleType = resolve(module)
+        return True # enough to check that module is loadable as ModuleType
     except ModuleNotFoundError:
         return False
     
-def is_package(package : Package) -> bool:
+def is_package(package : ModuleLike) -> bool:
     '''Determine whether a given Package-like (i.e. str or ModuleType) is a valid Python package'''
     try:
-        get_package(package)
-        return True
-    except (ModuleNotFoundError, TypeError):
+        module_loaded : ModuleType = resolve(package)
+        if (module_spec := module_loaded.__spec__) is None:
+            return False
+        return (module_spec.submodule_search_locations is not None)
+        # per importlib docs : "[submodule_search_locations] should be set to None for non-package modules"
+        # (https://docs.python.org/3/library/importlib.html#importlib.machinery.ModuleSpec.submodule_search_locations)
+    except (ModuleNotFoundError):
+        # DEV 05/15/2026 - removed TypeError, as this was only raised by the deprecated _common.get_package function
         return False
 
 # EXTRACTING MODULE NAMING INFO
-def flexible_module_pass(module : Union[str, Path, ModuleType]) -> ModuleType: # TODO: extend this to decorator
+def flexible_module_pass(module : ModuleLike | Path) -> ModuleType: # TODO: extend this to decorator
     '''Flexible interface for supplying a ModuleType object as an argument
     Allows for passing a name (either module name or string path), Path location, or a module proper'''
     if isinstance(module, (str, ModuleType)):

--- a/polymerist/genutils/importutils/pkginspect.py
+++ b/polymerist/genutils/importutils/pkginspect.py
@@ -17,11 +17,26 @@ ModuleLike = Union[str, ModuleType, Package]
 
 
 # CHECKING PACKAGE AND MODULE STATUS
+def _load_module(module : ModuleLike) -> ModuleType:
+    '''
+    Type-safe flexible resource load - raises ModuleNotFoundError if no ModuleType can be loaded
+    (to restrict the relatively-permissive importlib.resources._common.resolve())
+    '''
+    try:
+        module_loaded = resolve(module) # if string-y, will raise ModuleNotFoundError by default 
+    except AttributeError:
+        raise ModuleNotFoundError # Coercion needed to raise uniform Exception in testing between 3.11 and 3.12
+
+    if not hasattr(module_loaded, '__spec__'):
+        raise ModuleNotFoundError
+    
+    return module_loaded
+
 def is_module(module : ModuleLike) -> bool:
     '''Determine whether a given Package-like (i.e. str or ModuleType) is a valid Python module
     This will return True for packages, bottom-level modules (i.e. *.py) and Python scripts'''
     try:
-        module_loaded : ModuleType = resolve(module)
+        _ = _load_module(module)
         return True # enough to check that module is loadable as ModuleType
     except ModuleNotFoundError:
         return False
@@ -29,13 +44,11 @@ def is_module(module : ModuleLike) -> bool:
 def is_package(package : ModuleLike) -> bool:
     '''Determine whether a given Package-like (i.e. str or ModuleType) is a valid Python package'''
     try:
-        module_loaded : ModuleType = resolve(package)
-        if (module_spec := module_loaded.__spec__) is None:
-            return False
-        return (module_spec.submodule_search_locations is not None)
+        module_loaded : ModuleType = _load_module(package)
+        return (module_loaded.__spec__.submodule_search_locations is not None)
         # per importlib docs : "[submodule_search_locations] should be set to None for non-package modules"
         # (https://docs.python.org/3/library/importlib.html#importlib.machinery.ModuleSpec.submodule_search_locations)
-    except (ModuleNotFoundError):
+    except ModuleNotFoundError:
         # DEV 05/15/2026 - removed TypeError, as this was only raised by the deprecated _common.get_package function
         return False
 

--- a/polymerist/genutils/importutils/pkginspect.py
+++ b/polymerist/genutils/importutils/pkginspect.py
@@ -11,7 +11,7 @@ from importlib.resources import (
     Package,
     files as get_package_path
 )
-from importlib.resources._common import resolve, from_package, resolve
+from importlib.resources._common import get_package, from_package, resolve
 
 
 # CHECKING PACKAGE AND MODULE STATUS
@@ -27,7 +27,7 @@ def is_module(module : Package) -> bool:
 def is_package(package : Package) -> bool:
     '''Determine whether a given Package-like (i.e. str or ModuleType) is a valid Python package'''
     try:
-        resolve(package)
+        get_package(package)
         return True
     except (ModuleNotFoundError, TypeError):
         return False

--- a/polymerist/genutils/importutils/pkginspect.py
+++ b/polymerist/genutils/importutils/pkginspect.py
@@ -11,7 +11,7 @@ from importlib.resources import (
     Package,
     files as get_package_path
 )
-from importlib.resources._common import get_package, from_package, resolve
+from importlib.resources._common import resolve, from_package, resolve
 
 
 # CHECKING PACKAGE AND MODULE STATUS
@@ -27,7 +27,7 @@ def is_module(module : Package) -> bool:
 def is_package(package : Package) -> bool:
     '''Determine whether a given Package-like (i.e. str or ModuleType) is a valid Python package'''
     try:
-        get_package(package)
+        resolve(package)
         return True
     except (ModuleNotFoundError, TypeError):
         return False

--- a/polymerist/maths/lattices/coordinates.py
+++ b/polymerist/maths/lattices/coordinates.py
@@ -35,7 +35,7 @@ class Coordinates(Generic[Num]):
     @property
     def dimensions(self) -> np.ndarray[Shape[D], Num]:
         '''The side lengths of the bounding box along each dimension'''
-        return self.points.ptp(axis=0)
+        return np.ptp(self.points, axis=0)
     dims = sidelens = sidelengths = dimensions
 
     @property

--- a/polymerist/mdtools/openfftools/boxvectors.py
+++ b/polymerist/mdtools/openfftools/boxvectors.py
@@ -68,7 +68,7 @@ def get_topology_bbox(offtop : Topology) -> BoxVectorsQuantity:
         The unit-aware box vectors representing the smallest monoclinic
         bounding box which contains all atoms in the Topology
     '''
-    return xyz_to_box_vectors(offtop.get_positions().ptp(axis=0))
+    return xyz_to_box_vectors(np.ptp(offtop.get_positions(), axis=0))
 
 def _pad_box_vectors_unitless(box_vectors_mag : BoxVectors, pad_vec_mag : Vector) -> BoxVectors:
     '''Pad box vectors along each axis by a specified amount (given by each scalar component of a padding_vector)'''

--- a/polymerist/polymers/building/sequencing.py
+++ b/polymerist/polymers/building/sequencing.py
@@ -7,7 +7,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 from typing import Iterable, Optional
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, asdict
 
 from ...genutils.textual.substrings import shortest_repeating_substring, repeat_string_to_length
 from ...genutils.fileutils.jsonio.jsonify import make_jsonifiable
@@ -174,7 +174,7 @@ class LinearCopolymerSequencer:
         if (num_names_provided := len(end_group_names)) != self.n_repeat_units_terminal: # DEV: consider supporting filling in missing names with default in future
             raise IndexError(f'Defined sequence info with {self.n_repeat_units_terminal} end groups, but only provided names for {num_names_provided}')
         
-        # Insert middle omnomer parts as necessary
+        # Insert middle monomer parts as necessary
         sequence_middle = []
         if self.n_full_periods != 0: ## Whole sequence strings
             sequence_middle.append(f'{self.n_full_periods}*[{self.sequence_kernel}]')

--- a/polymerist/tests/genutils/importutils/test_pkginspect.py
+++ b/polymerist/tests/genutils/importutils/test_pkginspect.py
@@ -4,6 +4,7 @@ __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
 from types import ModuleType
+from dataclasses import dataclass
 
 import pytest
 from pathlib import Path
@@ -16,64 +17,66 @@ from polymerist.genutils.importutils import pkginspect
 from polymerist import tests
 
 
-
 # TABULATED EXPECTED TESTS OUTPUTS
-non_module_types = [ # types that are obviously not modules OR packages, and which should fail
-    bool, int, float, complex, tuple, list, dict, set, # str, Path # str and Path need to be tested separately
-]
+def non_module_types() ->list[type]:
+    '''Types that are obviously not modules OR packages, and which should fail'''
+    return [
+        bool, int, float, complex, tuple, list, dict, set, 
+        # str, Path # str and Path need to be tested separately
+    ]
 
-are_modules = [
-    ('--not_a_module--', False), # deliberately weird to ensure this never accidentally clashes with a legit module name
-    (math, True),
-    ('math', True), # test that the string -> module resolver also works as intended
-    (json, True),
-    ('json', True),
-    (json.decoder, True),
-    ('json.decoder', True),
-    (polymerist, True),
-    ('polymerist.polymerist', True),
-    (genutils, True),
-    ('polymerist.genutils', True),
-]
+@dataclass(frozen=True)
+class ModuleExample:
+    '''For encapsulating package and module check tests'''
+    resource : str | ModuleType
+    is_module : bool
+    is_package : bool
 
-are_packages = [
-    ('--not_a_package--', False), # deliberately weird to ensure this never accidentally clashes with a legit module name
-    (math, False),
-    ('math', False), # test that the string -> module resolver also works as intended
-    (json, True),
-    ('json', True),
-    (json.decoder, False),
-    ('json.decoder', False),
-    (polymerist, False),
-    ('polymerist.polymerist', False),
-    (genutils, True),
-    ('polymerist.genutils', True),
-]
+def module_examples() -> tuple[ModuleExample, ...]:
+    '''
+    Module-like objects labelled with whether they
+    are modules and whether they are packages
+    '''
+    return (
+        # deliberately weird to ensure this never accidentally clashes with a legit module name
+        ModuleExample('--not_a_module--', False, False), 
+        ModuleExample(math, True, False),
+        # test that the string -> module resolver also works as intended
+        ModuleExample('math', True, False), 
+        ModuleExample(json, True, True),
+        ModuleExample('json', True, True),
+        ModuleExample(json.decoder, True, False),
+        ModuleExample('json.decoder', True, False),
+        ModuleExample(polymerist, True, False),
+        ModuleExample('polymerist.polymerist', True, False),
+        ModuleExample(genutils, True, True),
+        ModuleExample('polymerist.genutils', True, True),
+    )
 
 
 # MODULE AND PACKAGE PERCEPTION
-@pytest.mark.parametrize('module, expected_output', are_modules)
-def test_is_module(module : ModuleType, expected_output : bool) -> None:
+@pytest.mark.parametrize('module_example', module_examples())
+def test_is_module(module_example : ModuleExample) -> None:
     '''See if Python module perception behaves as expected'''
-    assert pkginspect.is_module(module) == expected_output
+    assert pkginspect.is_module(module_example.resource) == module_example.is_module
 
-@pytest.mark.parametrize('non_module_type', non_module_types)
+@pytest.mark.parametrize('non_module_type', non_module_types())
 def test_is_module_fail_on_invalid_types(non_module_type : type) -> None:
     '''check that module perception fails on invalid inputs'''
     with pytest.raises(AttributeError) as err_info:
         instance = non_module_type() # create a default instance
         _ = pkginspect.is_module(instance)
 
-@pytest.mark.parametrize('module, expected_output', are_packages)
-def test_is_package(module : ModuleType, expected_output : bool) -> None:
+@pytest.mark.parametrize('module_example', module_examples())
+def test_is_package(module_example : ModuleExample) -> None:
     '''See if Python package perception behaves as expected'''
-    assert pkginspect.is_package(module) == expected_output
+    assert pkginspect.is_package(module_example.resource) == module_example.is_package
 
-@pytest.mark.parametrize('non_module_type', non_module_types) # NOTE: these args are in fact deliberately NOT renamed to ".*package" from ".*module"
-def test_is_module_fail_on_invalid_types(non_module_type : type) -> None:
+@pytest.mark.parametrize('non_package_type', non_module_types())
+def test_is_package_fail_on_invalid_types(non_package_type : type) -> None:
     '''check that package perception fails on invalid inputs'''
     with pytest.raises(AttributeError) as err_info:
-        instance = non_module_type() # create a default instance
+        instance = non_package_type() # create a default instance
         _ = pkginspect.is_package(instance)
 
 # FETCHING DATA FROM PACKAGES

--- a/polymerist/tests/genutils/importutils/test_pkginspect.py
+++ b/polymerist/tests/genutils/importutils/test_pkginspect.py
@@ -3,10 +3,12 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
+import pytest
+from _pytest.mark.structures import ParameterSet
+
 from types import ModuleType
 from dataclasses import dataclass
 
-import pytest
 from pathlib import Path
 import math, json # use these as test cases, since they are pretty stable in stdlib
 
@@ -24,6 +26,16 @@ def non_module_types() ->list[type]:
         bool, int, float, complex, tuple, list, dict, set, 
         # str, Path # str and Path need to be tested separately
     ]
+
+def obviously_fake_resource_param() ->ParameterSet:
+    return pytest.param(
+        'fake/whatever.txt', pkginspect,
+        marks=pytest.mark.xfail(
+            raises=(TypeError, ValueError), # DEVNOTE: annoyingly, Exception raised is TypeError in Python 3.11 but ValueError in 3.12
+            reason="Module is not a package and therefore cannot contain resources",
+            strict=True,
+        )
+    )
 
 @dataclass(frozen=True)
 class ModuleExample:
@@ -55,6 +67,13 @@ def module_examples() -> tuple[ModuleExample, ...]:
 
 
 # MODULE AND PACKAGE PERCEPTION
+@pytest.mark.parametrize('non_module_type', non_module_types())
+def test_invalid_module_type_rejected(non_module_type : type) -> None:
+    '''Check that module loading on obviously non-module types raises explicit Exception'''
+    with pytest.raises(ModuleNotFoundError) as err_info:
+        instance = non_module_type() # create a default instance
+        _ = pkginspect._load_module(instance)
+
 @pytest.mark.parametrize('module_example', module_examples())
 def test_is_module(module_example : ModuleExample) -> None:
     '''See if Python module perception behaves as expected'''
@@ -62,10 +81,9 @@ def test_is_module(module_example : ModuleExample) -> None:
 
 @pytest.mark.parametrize('non_module_type', non_module_types())
 def test_is_module_fail_on_invalid_types(non_module_type : type) -> None:
-    '''check that module perception fails on invalid inputs'''
-    with pytest.raises(AttributeError) as err_info:
-        instance = non_module_type() # create a default instance
-        _ = pkginspect.is_module(instance)
+    '''Check that module perception fails on invalid input types'''
+    instance = non_module_type() # create a default instance
+    assert not pkginspect.is_module(instance)
 
 @pytest.mark.parametrize('module_example', module_examples())
 def test_is_package(module_example : ModuleExample) -> None:
@@ -74,10 +92,9 @@ def test_is_package(module_example : ModuleExample) -> None:
 
 @pytest.mark.parametrize('non_package_type', non_module_types())
 def test_is_package_fail_on_invalid_types(non_package_type : type) -> None:
-    '''check that package perception fails on invalid inputs'''
-    with pytest.raises(AttributeError) as err_info:
-        instance = non_package_type() # create a default instance
-        _ = pkginspect.is_package(instance)
+    '''Check that package perception fails on invalid input types'''
+    instance = non_package_type() # create a default instance
+    assert not pkginspect.is_package(instance)
 
 # FETCHING DATA FROM PACKAGES
 @pytest.mark.parametrize(
@@ -85,9 +102,16 @@ def test_is_package_fail_on_invalid_types(non_package_type : type) -> None:
     [
         ('data', tests),
         ('data/sample.dat', tests),
-        pytest.param('daata/simple.dat', tests, marks=pytest.mark.xfail(raises=ValueError, reason="This isn't a real file", strict=True)),
+        pytest.param(
+            'daata/simple.dat', tests,
+            marks=pytest.mark.xfail(
+                raises=ValueError,
+                reason="This isn't a real file",
+                strict=True
+            ),
+        ),
         ('pkginspect.py', importutils),
-        pytest.param('fake/whatever.txt', pkginspect, marks=pytest.mark.xfail(raises=TypeError, reason="Module is not a package and therefore cannot contain resources", strict=True)),
+        obviously_fake_resource_param(),
     ]
 )
 def test_get_resource_path(rel_path : str, module : ModuleType) -> None:
@@ -98,11 +122,25 @@ def test_get_resource_path(rel_path : str, module : ModuleType) -> None:
 @pytest.mark.parametrize(
     'rel_path, module',
     [
-        pytest.param('data', tests, marks=pytest.mark.xfail(raises=FileNotFoundError, reason="This is a directory, NOT a file", strict=True)),
+        pytest.param(
+            'data', tests,
+            marks=pytest.mark.xfail(
+                raises=FileNotFoundError,
+                reason="This is a directory, NOT a file",
+                strict=True,
+            )
+        ),
         ('data/sample.dat', tests),
-        pytest.param('daata/simple.dat', tests, marks=pytest.mark.xfail(raises=ValueError, reason="This isn't a real file", strict=True)),
+        pytest.param(
+            'daata/simple.dat', tests,
+            marks=pytest.mark.xfail(
+                raises=ValueError,
+                reason="This isn't a real file",
+                strict=True,
+            )
+        ),
         ('pkginspect.py', importutils),
-        pytest.param('fake/whatever.txt', pkginspect, marks=pytest.mark.xfail(raises=TypeError, reason="Module is not a package and therefore cannot contain resources", strict=True)),
+        obviously_fake_resource_param(),
     ]
 )
 def test_get_file_path(rel_path : str, module : ModuleType) -> None:
@@ -114,10 +152,31 @@ def test_get_file_path(rel_path : str, module : ModuleType) -> None:
     'rel_path, module',
     [
         ('data', tests),
-        pytest.param('data/sample.dat', tests, marks=pytest.mark.xfail(raises=NotADirectoryError, reason='This IS a real file, but not a directory', strict=True)),
-        pytest.param('daata/simple.dat', tests, marks=pytest.mark.xfail(raises=ValueError, reason="This isn't a real file", strict=True)),
-        pytest.param('pkginspect.py', importutils, marks=pytest.mark.xfail(raises=NotADirectoryError, reason='This IS a real file, but not a directory', strict=True)),
-        pytest.param('fake/whatever.txt', pkginspect, marks=pytest.mark.xfail(raises=TypeError, reason="Module is not a package and therefore cannot contain resources", strict=True)),
+        pytest.param(
+            'data/sample.dat', tests,
+            marks=pytest.mark.xfail(
+                raises=NotADirectoryError,
+                reason='This IS a real file, but not a directory',
+                strict=True,
+            )
+        ),
+        pytest.param(
+            'daata/simple.dat', tests,
+            marks=pytest.mark.xfail(
+                raises=ValueError,
+                reason="This isn't a real file",
+                strict=True,
+            )
+        ),
+        pytest.param(
+            'pkginspect.py', importutils, 
+            marks=pytest.mark.xfail(
+                raises=NotADirectoryError,
+                reason='This IS a real file, but not a directory',
+                strict=True,
+            )
+        ),
+        obviously_fake_resource_param(),
     ]
 )
 def test_get_dir_path(rel_path : str, module : ModuleType) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
     "openmm",
     # DEV: as of 08/18/2025, latest stable version of lammps shipped w/ binaries on conda 
     # lammps-dependent code is unrunnable (citing MPI OSError) for more recent builds (i.e. 2025.MM.DD) 
-    # "lammps<=2024.08.29", 
-    "lammps", 
+    "lammps<=2024.08.29", 
 ]
 
 # Update the urls once the hosting is set up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.11"
 # Declare any run-time dependencies that should be installed with the package.
 dependencies = [
     "importlib-resources", # added to allow incorporation of `data` later on
-    "setuptools",   # added to avoid CI errors due to pkg_resources deprecation
+    "setuptools<82.0.0", # added to avoid CI errors due to pkg_resources deprecation
     "numpy>=2.0.0", # DEV: pinning this, as leaving it unpinned causes errors when importing mbuild (deprecated numpy.vecdot function)
     "scipy",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
-requires-python = "~=3.11"
+requires-python = ">=3.11"
 # Declare any run-time dependencies that should be installed with the package.
 dependencies = [
     "importlib-resources", # added to allow incorporation of `data` later on
-    "setuptools<82.0.0",   # added to avoid CI errors due to pkg_resources deprecation
-    "numpy<2.0.0", # DEV: pinning this, as leaving it unpinned causes errors when importing mbuild (deprecated numpy.vecdot function)
+    "setuptools",   # added to avoid CI errors due to pkg_resources deprecation
+    "numpy>=2.0.0", # DEV: pinning this, as leaving it unpinned causes errors when importing mbuild (deprecated numpy.vecdot function)
     "scipy",
     "pandas",
     "rich",
@@ -36,7 +36,8 @@ dependencies = [
     "openmm",
     # DEV: as of 08/18/2025, latest stable version of lammps shipped w/ binaries on conda 
     # lammps-dependent code is unrunnable (citing MPI OSError) for more recent builds (i.e. 2025.MM.DD) 
-    "lammps<=2024.08.29", 
+    # "lammps<=2024.08.29", 
+    "lammps", 
 ]
 
 # Update the urls once the hosting is set up.


### PR DESCRIPTION
## Description
Update package code and build config to allow use with Python 3.12+ as [Python 3.11 enters end-of-life](https://devguide.python.org/versions/).

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Enable `pip install polymerist` without dependency conflicts in envirnment with _at least_ Python 3.12
  - [x] Update with minimal changes to source, and without breaking [examples](https://github.com/timbernat/polymerist_examples)
  - [ ] Resolve #57

## Questions
- [x] What are sources of 3.12 incompatibility?
  - [x] In-code (e.g. typehints, which [did change](https://docs.python.org/3/whatsnew/3.12.html#pep-695-type-parameter-syntax))
    - [x] Update unit tests
    * _importlib.resources._common.get_package deprecation_
  - [x] Dependency (e.g. importlib, OpenFF)
    * _mBuild (a lot actually, including np.vecdot deprecation, pkg_resources, and mbuild.plugins)_
  - [x] Excise `espaloma-charge` from:
    - [x] Shipped conda envs
    - [x] ~Install instructions~
    - [x] ~Docs~ _NOTE: separated out into #61_

## Status
- [x] Confirm import across **all** subpackages
- [x] Verify CI workflow runs w/ 3.12 added to matrix
- [x] Check compat on PyPI (dev) release
- [x] Ready to go