### PR TITLE
Constrain Python 3.12 dependency updates

### DIFF
--- a/devtools/conda-envs/docs-env.yml
+++ b/devtools/conda-envs/docs-env.yml
@@ -4,7 +4,7 @@ channels:
     - openeye
 dependencies:
     # Basic Python dependencies
-    - python>=3.11
+    - python>=3.11,<3.13
     - pip
 
     # Unit testing

--- a/devtools/conda-envs/release-build.yml
+++ b/devtools/conda-envs/release-build.yml
@@ -4,9 +4,9 @@ channels:
     - openeye
 dependencies:
     # Basic Python dependencies
-    - python>=3.11.0
+    - python>=3.11,<3.13
     - pip
-    - setuptools
+    - setuptools<82 # to avoid ImportErrors from pkg_resources deprecation
 
     # Unit testing
     - pytest
@@ -35,7 +35,7 @@ dependencies:
     - rdkit
     - mbuild
     - openbabel
-    - packmol
+    - packmol<=20.15.1 # DEVNOTE: have no idea why, but versions tested later than this release (at least 20.16.1 and 21.0.4) introduce PDB CONECT errors where there were previously none
     - openeye-toolkits # TODO: consider making this optional?
 
     # MD engines

--- a/devtools/conda-envs/test-env.yml
+++ b/devtools/conda-envs/test-env.yml
@@ -4,9 +4,9 @@ channels:
     - openeye
 dependencies:
     # Basic Python dependencies
-    - python>=3.11.0
+    - python>=3.11,<3.13
     - pip
-    - setuptools
+    - setuptools<82 # to avoid ImportErrors from pkg_resources deprecation
 
     # Unit testing
     - pytest
@@ -28,8 +28,7 @@ dependencies:
     - rdkit
     - mbuild
     - openbabel
-    # - packmol<=20.15.1 # DEVNOTE: have no idea why, but versions tested later than this release (at least 20.16.1 and 21.0.4) introduce PDB CONECT errors where there were previously none
-    - packmol
+    - packmol<=20.15.1 # DEVNOTE: have no idea why, but versions tested later than this release (at least 20.16.1 and 21.0.4) introduce PDB CONECT errors where there were previously none
     - openeye-toolkits # TODO: consider making this optional?
 
     # MD engines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 # Declare any run-time dependencies that should be installed with the package.
 dependencies = [
     "importlib-resources", # added to allow incorporation of `data` later on
-    "setuptools",   # added to avoid CI errors due to pkg_resources deprecation
-    "numpy>=2.0.0", # DEV: pinning this, as leaving it unpinned causes errors when importing mbuild (deprecated numpy.vecdot function)
+    "setuptools<82.0.0",   # added to avoid CI errors due to pkg_resources deprecation
+    "numpy",
     "scipy",
     "pandas",
     "rich",
@@ -36,8 +36,7 @@ dependencies = [
     "openmm",
     # DEV: as of 08/18/2025, latest stable version of lammps shipped w/ binaries on conda 
     # lammps-dependent code is unrunnable (citing MPI OSError) for more recent builds (i.e. 2025.MM.DD) 
-    # "lammps<=2024.08.29", 
-    "lammps", 
+    "lammps<=2024.08.29", 
 ]
 
 # Update the urls once the hosting is set up.


### PR DESCRIPTION
This is a small follow-up to PR #58 based on dependency solver debugging for Python 3.12.
### Findings:
- The source-level Python 3.12 issue is the private `importlib.resources._common` usage in `pkginspect.py`; the existing PR fix using `ModuleSpec.submodule_search_locations` looks correct.
- Current conda-forge can solve python=3.12 with mbuild + openff-toolkit, and with mbuild-base + openff-toolkit-base. That pair does not appear to be the current hard blocker.
- The broader test/optional stack has an opposing NumPy constraint: current mbuild pulls gmso>=0.16.1, which requires numpy>=2.0, while espaloma_charge pulls dgl -> tensorflow-base=2.17.0, whose Python 3.12 build requires numpy>=1.26.4,<2.0a0.
- The saved sequential-install logs in polymerist_py312_context were pinned to python 3.13.*, not 3.12. For this PR, opening requires-python to unbounded >=3.11 makes the solver test future Python versions that are outside the intended compatibility target.
### Changes here:
- Cap Polymerist support to >=3.11,<3.13 for this pass.
- Remove the pyproject numpy>=2 runtime requirement so Polymerist does not force one side of the mbuild/GMSO vs Espaloma/TensorFlow conflict.
- Restore setuptools<82 and the unrelated packmol/lammps pins instead of changing them in the Python 3.12 compatibility PR.
### Validation run locally:
- mamba dry-run solve for the updated Python 3.12 runtime dependency set succeeded.
- mamba dry-run python=3.12 mbuild openff-toolkit succeeded.
- Focused test: mamba run -n polymerist-env python -m pytest -q polymerist/tests/genutils/importutils/test_pkginspect.py -> 44 passed, 9 xfailed.