### PR TITLE
Disambiguating HTTP-related failures in chemdbqueries tests

### DIFF
--- a/polymerist/smileslib/chemdbqueries.py
+++ b/polymerist/smileslib/chemdbqueries.py
@@ -6,14 +6,32 @@ __email__ = 'timotej.bernat@colorado.edu'
 import logging
 LOGGER  = logging.getLogger(__name__)
 
-from typing import Any, ClassVar, Container, Iterable, Optional, Sequence
+from typing import (
+    Any, 
+    ClassVar, 
+    Container, 
+    Iterable, 
+    Optional, 
+    Sequence,
+)
 from abc import ABC, abstractmethod
 
-import requests
+from http.client import RemoteDisconnected
+from requests.exceptions import HTTPError
 from requests.structures import CaseInsensitiveDict
+from requests.api import (
+    get as request_get,
+    head as request_head,
+)
 
-from ..genutils.decorators.classmod import register_abstract_class_attrs, register_subclasses
-from ..genutils.importutils.dependencies import requires_modules, MissingPrerequisitePackage
+from ..genutils.decorators.classmod import (
+    register_abstract_class_attrs,
+    register_subclasses,
+)
+from ..genutils.importutils.dependencies import (
+    requires_modules,
+    MissingPrerequisitePackage,
+)
 
 
 # CUSTOM EXCEPTIONS
@@ -178,7 +196,7 @@ class NIHCACTUSQueryStrategy(ChemDBServiceQueryStrategy):
     
     @classmethod
     def is_online(cls):
-        response = requests.head('https://cactus.nci.nih.gov/chemical/structure')
+        response = request_head('https://cactus.nci.nih.gov/chemical/structure')
         # NOTE: could also be more stringent and check == 200 for OK; enough to just check server-side error for now
         return response.status_code < 500 
     
@@ -235,7 +253,7 @@ class PubChemQueryStrategy(ChemDBServiceQueryStrategy):
     
     @classmethod
     def is_online(cls):
-        response = requests.get(
+        response = request_get(
             'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/aspirin/property/IUPACName/TXT'
         ) # sample query which is well-formatted
         return response.status_code < 500 # NOTE: enough to just check server-side error for now, but could be more stringent and check if ==200
@@ -273,17 +291,26 @@ class PubChemQueryStrategy(ChemDBServiceQueryStrategy):
         namespace : Optional[str]='smiles',
         **kwargs
     ) -> Optional[Any]:
-        import pubchempy as pcp
+        from pubchempy import (
+            get_properties,
+            PubChemPyError,
+            PubChemHTTPError,
+        )
         
         try:
-            pubchem_result = pcp.get_properties(
+            pubchem_result = get_properties(
                 properties=property_name, 
                 identifier=identifier,
-                namespace=namespace, 
+                namespace=namespace,
+                as_dataframe=False,
                 **kwargs,
             )
-        except pcp.PubChemPyError:
-            raise requests.HTTPError # discards some information in return for making Strategy interface oblivious to pubchempy (i.e. in case it is not installed)
+        except PubChemHTTPError as exc:
+            LOGGER.error(f'PubChemPy threw error with code {exc.code}')
+            raise HTTPError # discards some information in return for making Strategy interface oblivious to pubchempy (i.e. in case it is not installed)
+        except RemoteDisconnected:
+            LOGGER.error('Server disconnected response')
+            raise HTTPError # discards some information in return for making Strategy interface oblivious to pubchempy (i.e. in case it is not installed)
         else:
             if pubchem_result:
                 # remove underscores to compatibilize naming hits (property names returned from PubChem will never contain underscores)
@@ -340,7 +367,7 @@ def get_chemical_property(
                 **kwargs,
             )
             return prop_val
-        except requests.HTTPError:
+        except HTTPError:
             LOGGER.error(f'Query to {service.service_name} failed, either due to connection timeout or invalid request')
             continue
         except (InvalidPropertyError, NullPropertyResponse): # skip over invalid property names (keep trying other services rather than failing)

--- a/polymerist/smileslib/chemdbqueries.py
+++ b/polymerist/smileslib/chemdbqueries.py
@@ -71,14 +71,14 @@ class ChemDBServiceQueryStrategy(ABC):
             raise InvalidPropertyError(f'{prop_error_msg};\nChoose from one of the following property names:\n{prop_options_str}')
         
     def get_property(
-            self, 
-            property_name : str, 
-            identifier : str, 
-            namespace : Optional[str],
-            keep_first_only : bool=True,
-            allow_null_return : bool=False,
-            **kwargs
-        ) -> Optional[Any]:
+        self, 
+        property_name : str, 
+        identifier : str, 
+        namespace : Optional[str],
+        keep_first_only : bool=True,
+        allow_null_return : bool=False,
+        **kwargs
+    ) -> Optional[Any]:
         '''Fetch a property associated with a molecule from a chemical database query service'''
         property_name = property_name.casefold() # avoid needing to account for case-sensitivity in property name check
         LOGGER.info(f'Sent query request for property "{property_name}" to {self.service_name}')
@@ -88,10 +88,12 @@ class ChemDBServiceQueryStrategy(ABC):
         if not prop_val:
             prop_val = None # cast empty lists, strings, etc to NoneType
         
-        if isinstance(prop_val, Container) and not isinstance(prop_val, str) and keep_first_only: # avoid bug where first char of string response is returned
+        # avoid bug where first char of string response is returned
+        if isinstance(prop_val, Container) and not isinstance(prop_val, str) and keep_first_only: 
             prop_val = prop_val[0]
         
-        if (prop_val is None) and (not allow_null_return): # NOTE: duplicated NoneType check is needed to catch empty containers which are cast to None above
+        # NOTE: duplicated NoneType check is needed to catch empty containers which are cast to None above
+        if (prop_val is None) and (not allow_null_return): 
             null_error_msg = f'{self.service_name} returned NoneType "{property_name}", which is declared invalid by call signature'
             LOGGER.error(null_error_msg)
             
@@ -126,7 +128,8 @@ class NIHCACTUSQueryStrategy(ChemDBServiceQueryStrategy):
     def queryable_properties(cls) -> set[str]:
         import cirpy 
         
-        _CIR_PROPS = {  # see official docs for more info: https://cactus.nci.nih.gov/chemical/structure_documentation
+        # see official docs for more info: https://cactus.nci.nih.gov/chemical/structure_documentation
+        _CIR_PROPS = {  
             # Chemical Representations
             'smiles',
             'names',
@@ -156,7 +159,8 @@ class NIHCACTUSQueryStrategy(ChemDBServiceQueryStrategy):
             'effective_rotor_count',
             'ring_count',
             'ringsys_count',
-            ## these were not documented on CACTUS or by cirpy, but scraped from webchem: https://github.com/ropensci/webchem/blob/master/R/cir.R#L168-L174
+            ## these were not documented on CACTUS or by cirpy, but scraped from 
+            ## webchem: https://github.com/ropensci/webchem/blob/master/R/cir.R#L168-L174
             'deprotonable_group_count',
             'heavy_atom_count',
             'heteroatom_count',
@@ -168,12 +172,15 @@ class NIHCACTUSQueryStrategy(ChemDBServiceQueryStrategy):
             # 'image', # for some reason, image query returns internal server error in testing
             # 'twirl', # NOTE: this is documented on the CIR site, but raises XML error in practice
         }
-        return _CIR_PROPS | cirpy.FILE_FORMATS # see here for file formats: https://cirpy.readthedocs.io/en/latest/guide/gettingstarted.html#file-formats
+        # see here for file formats: https://cirpy.readthedocs.io/en/latest/guide/gettingstarted.html#file-formats
+        
+        return _CIR_PROPS | cirpy.FILE_FORMATS 
     
     @classmethod
     def is_online(cls):
         response = requests.head('https://cactus.nci.nih.gov/chemical/structure')
-        return response.status_code < 500 # NOTE: could also be more stringent and check == 200 for OK; enough to just check server-side error for now
+        # NOTE: could also be more stringent and check == 200 for OK; enough to just check server-side error for now
+        return response.status_code < 500 
     
     @classmethod
     def queryable_namespaces(cls) -> set[str]:
@@ -190,7 +197,13 @@ class NIHCACTUSQueryStrategy(ChemDBServiceQueryStrategy):
         }
     
     @requires_modules('cirpy', missing_module_error=cirpy_error)
-    def _get_property(self, property_name : str, identifier : str, namespace : Optional[str]=None, **kwargs):
+    def _get_property(
+        self,
+        property_name : str,
+        identifier : str,
+        namespace : Optional[str]=None,
+        **kwargs,
+    ):
         import cirpy
         
         return cirpy.resolve(
@@ -222,7 +235,9 @@ class PubChemQueryStrategy(ChemDBServiceQueryStrategy):
     
     @classmethod
     def is_online(cls):
-        response = requests.get('https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/aspirin/property/IUPACName/TXT') # sample query which is well-formatted
+        response = requests.get(
+            'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/aspirin/property/IUPACName/TXT'
+        ) # sample query which is well-formatted
         return response.status_code < 500 # NOTE: enough to just check server-side error for now, but could be more stringent and check if ==200
         
     @classmethod
@@ -251,7 +266,13 @@ class PubChemQueryStrategy(ChemDBServiceQueryStrategy):
         }
     
     @requires_modules('pubchempy', missing_module_error=pubchempy_error)
-    def _get_property(self, property_name : str, identifier : str, namespace : Optional[str]='smiles', **kwargs) -> Optional[Any]:
+    def _get_property(
+        self,
+        property_name : str,
+        identifier : str,
+        namespace : Optional[str]='smiles',
+        **kwargs
+    ) -> Optional[Any]:
         import pubchempy as pcp
         
         try:
@@ -265,25 +286,28 @@ class PubChemQueryStrategy(ChemDBServiceQueryStrategy):
             raise requests.HTTPError # discards some information in return for making Strategy interface oblivious to pubchempy (i.e. in case it is not installed)
         else:
             if pubchem_result:
-                property_name_no_under = property_name.replace('_', '') # remove underscores to compatibilize naming hits (property names returned from PubChem will never contain underscores)
-                pubchem_result = [ # extract the requested property field from the full return fields pubchempy returns
-                    case_insensitive_query_result[property_name_no_under] # extract property value from extraneous CID (and any other) info
-                        for case_insensitive_query_result in map(CaseInsensitiveDict, pubchem_result) # allows case-insensitive matching to query names
-                            if property_name_no_under in case_insensitive_query_result # skip if return doesn't contain the info we specifically requested (happens occasionally for some reason)
+                # remove underscores to compatibilize naming hits (property names returned from PubChem will never contain underscores)
+                property_name_no_under = property_name.replace('_', '') 
+                pubchem_result = [
+                    # extract property value from extraneous CID (and any other) info
+                    case_insensitive_query_result[property_name_no_under] 
+                        for case_insensitive_query_result in map(CaseInsensitiveDict, pubchem_result)
+                            # skip if return doesn't contain the info we specifically requested (happens occasionally for some reason)
+                            if property_name_no_under in case_insensitive_query_result 
                 ] 
             return pubchem_result
         
 # UTILITY FUNCTIONS EMPLOYING GENERIC STRATEG(Y/IES)
 def get_chemical_property(
-        property_name : str, 
-        identifier : str, 
-        namespace : str='smiles',
-        keep_first_only : bool=True,
-        allow_null_return : bool=False,
-        fail_quietly : bool=False,
-        services : Optional[Sequence['ChemDBServiceQueryStrategy']]=None,
-        **kwargs,
-    ) -> Optional[Any]:
+    property_name : str, 
+    identifier : str, 
+    namespace : str='smiles',
+    keep_first_only : bool=True,
+    allow_null_return : bool=False,
+    fail_quietly : bool=False,
+    services : Optional[Sequence['ChemDBServiceQueryStrategy']]=None,
+    **kwargs,
+) -> Optional[Any]:
     '''Attempt to fetch a molecular property from a variety of chemical database services, either
     provided manually (in the order they should be checked) or ALL implemented service queries by default
     

--- a/polymerist/smileslib/chemdbqueries.py
+++ b/polymerist/smileslib/chemdbqueries.py
@@ -53,7 +53,12 @@ class ChemicalDataQueryFailed(Exception):
 class ChemDBServiceQueryStrategy(ABC):
     '''Implementation of queries from a particular chemical database'''
     @abstractmethod
-    def _get_property(self, property_name : str, identifier : str, **kwargs) -> Optional[Any]:
+    def _get_property(
+        self,
+        property_name : str,
+        identifier : str,
+        **kwargs,
+    ) -> Optional[Any]:
         ...
         
     @classmethod

--- a/polymerist/smileslib/chemdbqueries.py
+++ b/polymerist/smileslib/chemdbqueries.py
@@ -312,10 +312,18 @@ class PubChemQueryStrategy(ChemDBServiceQueryStrategy):
             )
         except PubChemHTTPError as exc:
             LOGGER.error(f'PubChemPy threw error with code {exc.code}')
-            raise HTTPError # discards some information in return for making Strategy interface oblivious to pubchempy (i.e. in case it is not installed)
+            # discards some information in return for making downstream handlers 
+            # (e.g. unit tests) oblivious to pubchempy, avoiding need for that import 
+            stdlib_err = HTTPError() 
+            stdlib_err.code = exc.code 
+
+            raise stdlib_err
         except RemoteDisconnected:
             LOGGER.error('Server disconnected response')
-            raise HTTPError # discards some information in return for making Strategy interface oblivious to pubchempy (i.e. in case it is not installed)
+            stdlib_err = HTTPError() 
+            stdlib_err.code = 503 # HTTP 503: server is down for maintenance or overloaded (i.e. too many requests made)
+
+            raise stdlib_err 
         else:
             if pubchem_result:
                 # remove underscores to compatibilize naming hits (property names returned from PubChem will never contain underscores)

--- a/polymerist/tests/smileslib/test_chemdbqueries.py
+++ b/polymerist/tests/smileslib/test_chemdbqueries.py
@@ -244,7 +244,7 @@ VARIED_PARAMETER_EXAMPLES : list[
         ),
         None,
         marks=pytest.mark.xfail(
-            raises=(ChemicalDataQueryFailed),
+            raises=(ChemicalDataQueryFailed, HTTPError), # DEVNOTE: HTTPError here is absolutely necessary! Request should return HTTP error 400
             reason='Invalid request sent to PubChem (queried a name as a SMILES string)',
             strict=True,
         )

--- a/polymerist/tests/smileslib/test_chemdbqueries.py
+++ b/polymerist/tests/smileslib/test_chemdbqueries.py
@@ -6,7 +6,7 @@ __email__ = 'timotej.bernat@colorado.edu'
 import pytest
 from _pytest.mark import ParameterSet
 
-from typing import Any
+from typing import Any, Optional
 from dataclasses import dataclass, asdict
 
 from requests import HTTPError
@@ -26,6 +26,11 @@ from polymerist.smileslib.chemdbqueries import (
     
 )
 
+TIMEOUT_ERR_CODES : set[int] = {
+    500, # SERVER-SIDE PROBLEM
+    503, # MAINTENANCE OR OVERLOAD
+    504, # TIMEOUT
+}
 CHEMDB_STRATEGY_ONLINE : dict[type[ChemDBServiceQueryStrategy], bool] = {}
 CHEMDB_STRATEGY_DEPENDENCIES_MET : dict[type[ChemDBServiceQueryStrategy], bool] = {}
 for ChemDBStrategy in ChemDBServiceQueryStrategy.__subclasses__(): # dynamically determine criteria for which services should be tested
@@ -239,7 +244,7 @@ VARIED_PARAMETER_EXAMPLES : list[
         ),
         None,
         marks=pytest.mark.xfail(
-            raises=(HTTPError, ChemicalDataQueryFailed),
+            raises=(ChemicalDataQueryFailed),
             reason='Invalid request sent to PubChem (queried a name as a SMILES string)',
             strict=True,
         )
@@ -303,10 +308,19 @@ class TestChemicalDatabaseServiceQueries:
         '''Test that the properties each service type lists as queryable do indeed return valid results'''
         skip_pytest_on_invalid_service(service_type=service_type)
         service = service_type()
-        _ = service.get_property(property_name=property_name, **asdict(query_params)) # no assert, simply checking that this doesn't raise Exception
-    
+        
+        try:
+            # no assert, simply checking that this doesn't raise Exception
+            _ = service.get_property(property_name=property_name, **asdict(query_params)) 
+        except HTTPError as exc:
+            http_err_code : Optional[int] = getattr(exc, 'code', None)
+            if http_err_code in TIMEOUT_ERR_CODES:
+                pytest.skip('Overloaded server or request denied; test will be inconclusive')
+            else:
+                raise exc
+
     @pytest.mark.parametrize(
-        'property_name,service_type,query_params,expected_return',
+        'property_name,service_type,query_params,expected_property',
         VARIED_PARAMETER_EXAMPLES,
     )
     def test_direct_service_property_query(
@@ -314,15 +328,27 @@ class TestChemicalDatabaseServiceQueries:
         property_name : str,
         service_type : type[ChemDBServiceQueryStrategy],
         query_params : ChemDBQueryParameters,
-        expected_return : Any,
+        expected_property : Any,
     ) -> None:
         '''Test if a chemical database query through a given service is executed completely and returns the expected result'''
         skip_pytest_on_invalid_service(service_type=service_type)
         service = service_type()
-        assert service.get_property(property_name=property_name, **asdict(query_params)) == expected_return
+        try:
+            actual_property = service.get_property(
+                property_name=property_name,
+                **asdict(query_params),
+            )
+        except HTTPError as exc:
+            http_err_code : Optional[int] = getattr(exc, 'code', None)
+            if http_err_code in TIMEOUT_ERR_CODES:
+                pytest.skip('Overloaded server or request denied; test will be inconclusive')
+            else:
+                raise exc
+        else:
+            assert actual_property == expected_property
         
     @pytest.mark.parametrize(
-        'property_name,service_type,query_params,expected_return',
+        'property_name,service_type,query_params,expected_property',
         VARIED_PARAMETER_EXAMPLES,
     )
     def test_get_chemical_property_wrapper(
@@ -330,10 +356,23 @@ class TestChemicalDatabaseServiceQueries:
         property_name : str,
         service_type : type[ChemDBServiceQueryStrategy],
         query_params : ChemDBQueryParameters,
-        expected_return : Any,
+        expected_property : Any,
     ) -> None:
         '''Test that requests filtered through the get_chemical_properties() strategy wrapper are executed faithfully'''
         skip_pytest_on_invalid_service(service_type=service_type)
-        assert get_chemical_property(property_name, **asdict(query_params), services=[service_type], fail_quietly=False) == expected_return # CRUCIAL that fail_quietly be False; rely on exceptions to match with xfails
-        # except ChemicalDataQueryFailed:
+        try:
+            actual_property = get_chemical_property(
+                property_name,
+                **asdict(query_params),
+                services=[service_type],
+                fail_quietly=False, # CRUCIAL that fail_quietly be False; rely on exceptions to match with xfails
+            )
+        except HTTPError as exc:
+            http_err_code : Optional[int] = getattr(exc, 'code', None)
+            if http_err_code in TIMEOUT_ERR_CODES:
+                pytest.skip('Overloaded server or request denied; test will be inconclusive')
+            else:
+                raise exc
+        else:
+            assert actual_property == expected_property 
     

--- a/polymerist/tests/smileslib/test_chemdbqueries.py
+++ b/polymerist/tests/smileslib/test_chemdbqueries.py
@@ -4,6 +4,7 @@ __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
 import pytest
+from _pytest.mark import ParameterSet
 
 from typing import Any
 from dataclasses import dataclass, asdict
@@ -25,8 +26,8 @@ from polymerist.smileslib.chemdbqueries import (
     
 )
 
-CHEMDB_STRATEGY_ONLINE : dict[str, bool] = {}
-CHEMDB_STRATEGY_DEPENDENCIES_MET : dict[ChemDBServiceQueryStrategy, bool] = {}
+CHEMDB_STRATEGY_ONLINE : dict[type[ChemDBServiceQueryStrategy], bool] = {}
+CHEMDB_STRATEGY_DEPENDENCIES_MET : dict[type[ChemDBServiceQueryStrategy], bool] = {}
 for ChemDBStrategy in ChemDBServiceQueryStrategy.__subclasses__(): # dynamically determine criteria for which services should be tested
     CHEMDB_STRATEGY_ONLINE[          ChemDBStrategy] = ChemDBStrategy.is_online()
     CHEMDB_STRATEGY_DEPENDENCIES_MET[ChemDBStrategy] = modules_installed(*ChemDBStrategy.dependencies())
@@ -85,7 +86,14 @@ FIXED_PARAMETER_EXAMPLES : list[tuple[str, type[ChemDBServiceQueryStrategy], Che
 ]
 
 # examples which test that many diverse inputs yield expected outputs
-VARIED_PARAMETER_EXAMPLES : list[tuple[str, type[ChemDBServiceQueryStrategy], ChemDBQueryParameters, Any]] = [
+VARIED_PARAMETER_EXAMPLES : list[
+    tuple[
+        str,
+        type[ChemDBServiceQueryStrategy],
+        ChemDBQueryParameters,
+        Any,
+    ] | ParameterSet
+] = [
     # for NIH CACTUS
     ( ## simple queries known to work for all services
         'iupac_name',
@@ -282,22 +290,48 @@ VARIED_PARAMETER_EXAMPLES : list[tuple[str, type[ChemDBServiceQueryStrategy], Ch
 ]
     
 class TestChemicalDatabaseServiceQueries:
-    @pytest.mark.parametrize('property_name,service_type,query_params', FIXED_PARAMETER_EXAMPLES)
-    def test_queryable_properties(self, property_name : str, service_type : type[ChemDBServiceQueryStrategy], query_params : ChemDBQueryParameters) -> None:
+    @pytest.mark.parametrize(
+        'property_name,service_type,query_params',
+        FIXED_PARAMETER_EXAMPLES,
+    )
+    def test_queryable_properties(
+        self,
+        property_name : str,
+        service_type : type[ChemDBServiceQueryStrategy],
+        query_params : ChemDBQueryParameters,
+    ) -> None:
         '''Test that the properties each service type lists as queryable do indeed return valid results'''
         skip_pytest_on_invalid_service(service_type=service_type)
         service = service_type()
         _ = service.get_property(property_name=property_name, **asdict(query_params)) # no assert, simply checking that this doesn't raise Exception
     
-    @pytest.mark.parametrize('property_name,service_type,query_params,expected_return', VARIED_PARAMETER_EXAMPLES)
-    def test_direct_service_property_query(self, property_name : str, service_type : type[ChemDBServiceQueryStrategy], query_params : ChemDBQueryParameters, expected_return : Any) -> None:
+    @pytest.mark.parametrize(
+        'property_name,service_type,query_params,expected_return',
+        VARIED_PARAMETER_EXAMPLES,
+    )
+    def test_direct_service_property_query(
+        self,
+        property_name : str,
+        service_type : type[ChemDBServiceQueryStrategy],
+        query_params : ChemDBQueryParameters,
+        expected_return : Any,
+    ) -> None:
         '''Test if a chemical database query through a given service is executed completely and returns the expected result'''
         skip_pytest_on_invalid_service(service_type=service_type)
         service = service_type()
         assert service.get_property(property_name=property_name, **asdict(query_params)) == expected_return
         
-    @pytest.mark.parametrize('property_name,service_type,query_params,expected_return', VARIED_PARAMETER_EXAMPLES)
-    def test_get_chemical_property_wrapper(self, property_name : str, service_type : type[ChemDBServiceQueryStrategy], query_params : ChemDBQueryParameters, expected_return : Any) -> None:
+    @pytest.mark.parametrize(
+        'property_name,service_type,query_params,expected_return',
+        VARIED_PARAMETER_EXAMPLES,
+    )
+    def test_get_chemical_property_wrapper(
+        self,
+        property_name : str,
+        service_type : type[ChemDBServiceQueryStrategy],
+        query_params : ChemDBQueryParameters,
+        expected_return : Any,
+    ) -> None:
         '''Test that requests filtered through the get_chemical_properties() strategy wrapper are executed faithfully'''
         skip_pytest_on_invalid_service(service_type=service_type)
         assert get_chemical_property(property_name, **asdict(query_params), services=[service_type], fail_quietly=False) == expected_return # CRUCIAL that fail_quietly be False; rely on exceptions to match with xfails


### PR DESCRIPTION
## Description
PubChemPy enforces a maximum "5 queries per second" limit in its PUGREST query API which this library frequently exceeds in CI matrix runs, causing false positive test failures due to dynamic throttling, rather than any issue with the code in this library. This PR aims to make response error handling and related tests aware of these shutoffs, and to handle these exceptions more gracefully to provide more helpful CI results

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] [chembdqueries.py sources](https://github.com/timbernat/polymerist/blob/main/polymerist/smileslib/chemdbqueries.py)
    - [x] Make pubchem-agnostic HTTPError wrap retain context about _why_ request failed
  - [x] test_chemdbqueries.py:
    - [x] Catch and skip tests related to server disconnections (namely, codes [500](https://github.com/mcs07/PubChemPy/blob/main/pubchempy.py#L2127-L2128), [503](https://github.com/mcs07/PubChemPy/blob/main/pubchempy.py#L2135-L2136), and [504](https://github.com/mcs07/PubChemPy/blob/main/pubchempy.py#L2139-L2143))

## Questions
- [x] Question1

## Status
- [x] Check CI passes
  - [x] Attempt multiple runs before changes to see if errors are logged first (i.e. intentionally overload server requests and see if they can be detected in tests)