### PR TITLE
Testing and debug cleanup

### DIFF
--- a/polymerist/mdtools/openfftools/solvation/solvents/__init__.py
+++ b/polymerist/mdtools/openfftools/solvation/solvents/__init__.py
@@ -29,7 +29,6 @@ def generate_water_TIP3P() -> Molecule:
 
 
 # predefine water file, if not already present
-print('new stuff')
 _water_path = _MODULE_PATH / 'water_TIP3P.sdf'
 if not _water_path.exists():
     water = generate_water_TIP3P()

--- a/polymerist/smileslib/chemdbqueries.py
+++ b/polymerist/smileslib/chemdbqueries.py
@@ -9,7 +9,7 @@ LOGGER  = logging.getLogger(__name__)
 from typing import (
     Any, 
     ClassVar, 
-    Container, 
+    Collection,
     Iterable, 
     Optional, 
     Sequence,
@@ -74,13 +74,13 @@ class ChemDBServiceQueryStrategy(ABC):
         
     @classmethod
     @abstractmethod
-    def queryable_properties(cls) -> Container[str]:
+    def queryable_properties(cls) -> Collection[str]:
         '''List which chemical property names can be queried from the service'''
         ...
 
     @classmethod
     @abstractmethod
-    def queryable_namespaces(cls) -> Container[str]:
+    def queryable_namespaces(cls) -> Collection[str]:
         '''List which chemical identification types can be searched through by the service'''
         ...
         
@@ -112,7 +112,7 @@ class ChemDBServiceQueryStrategy(ABC):
             prop_val = None # cast empty lists, strings, etc to NoneType
         
         # avoid bug where first char of string response is returned
-        if isinstance(prop_val, Container) and not isinstance(prop_val, str) and keep_first_only: 
+        if isinstance(prop_val, Collection) and not isinstance(prop_val, str) and keep_first_only: 
             prop_val = prop_val[0]
         
         # NOTE: duplicated NoneType check is needed to catch empty containers which are cast to None above

--- a/polymerist/smileslib/functgroups/_daylight_scrape.py
+++ b/polymerist/smileslib/functgroups/_daylight_scrape.py
@@ -45,7 +45,6 @@ def scrape_SMARTS(url : str=DAYLIGHT_URL) -> pd.DataFrame:
                 group_name, SMARTS, SMARTS_desc = *term.stripped_strings, ''
             else:
                 pass
-                # print(len(text), any('example' in w.lower() for w in text), text)
 
             entry = FnGroupSMARTSEntry(category, category_desc, group_type, group_name, SMARTS, SMARTS_desc)
             entries.add(entry)

--- a/polymerist/tests/rdutils/reactions/test_reaction.py
+++ b/polymerist/tests/rdutils/reactions/test_reaction.py
@@ -90,8 +90,6 @@ def test_reaction(rxn_smarts : Smarts, reactant_smiles : tuple[Smiles], expected
     assert len(products_actual) == len(products_expected), 'Mismatched number of products compared to expectation'
 
     for product_expected, product_actual in zip(products_expected, products_actual, strict=True):
-        print(Chem.MolToSmiles(product_expected, canonical=True))
-        print(Chem.MolToSmiles(product_actual, canonical=True))
         assert Chem.MolToSmiles(product_expected, canonical=True) == Chem.MolToSmiles(product_actual, canonical=True), 'Mismatches product'
     
     

--- a/polymerist/tests/smileslib/test_chemdbqueries.py
+++ b/polymerist/tests/smileslib/test_chemdbqueries.py
@@ -28,8 +28,9 @@ from polymerist.smileslib.chemdbqueries import (
 
 TIMEOUT_ERR_CODES : set[int] = {
     500, # SERVER-SIDE PROBLEM
+    502, # INVALID GATEWAY/PROXY RESPONSE UPSTREAM
     503, # MAINTENANCE OR OVERLOAD
-    504, # TIMEOUT
+    504, # REQUEST TIMEOUT
 }
 CHEMDB_STRATEGY_ONLINE : dict[type[ChemDBServiceQueryStrategy], bool] = {}
 CHEMDB_STRATEGY_DEPENDENCIES_MET : dict[type[ChemDBServiceQueryStrategy], bool] = {}

--- a/polymerist/tests/smileslib/test_chemdbqueries.py
+++ b/polymerist/tests/smileslib/test_chemdbqueries.py
@@ -18,8 +18,8 @@ from polymerist.smileslib.chemdbqueries import (
     NullPropertyResponse,
     ChemicalDataQueryFailed,
     ChemDBServiceQueryStrategy,
-    # NOTE: these strageies are implemented to be defined even if the packages in question aren't installed
-    # it's just that instances will raise excception on most of their method calls
+    # NOTE: these strategies are defined even if their dependencies aren't installed
+    # their object instances will just raise Exception on most of their method calls
     NIHCACTUSQueryStrategy,
     PubChemQueryStrategy,
     get_chemical_property,
@@ -38,7 +38,7 @@ for ChemDBStrategy in ChemDBServiceQueryStrategy.__subclasses__(): # dynamically
     CHEMDB_STRATEGY_ONLINE[          ChemDBStrategy] = ChemDBStrategy.is_online()
     CHEMDB_STRATEGY_DEPENDENCIES_MET[ChemDBStrategy] = modules_installed(*ChemDBStrategy.dependencies())
     
-def skip_pytest_on_invalid_service(service_type : ChemDBServiceQueryStrategy) -> None:
+def skip_pytest_on_invalid_service(service_type : type[ChemDBServiceQueryStrategy]) -> None:
     '''
     Boilerplate function for skipping a test if the requested database
     query service is either missing local dependencies or is offline
@@ -77,228 +77,230 @@ class ChemDBQueryParameters:
     keep_first_only : bool
     allow_null_return : bool
 
-# examples which test
-ETHANOL_PARAMS = ChemDBQueryParameters(
-    identifier='CCO',
-    namespace='smiles',
-    keep_first_only=True,
-    allow_null_return=True, 
-)
-FIXED_PARAMETER_EXAMPLES : list[tuple[str, type[ChemDBServiceQueryStrategy], ChemDBQueryParameters, Any]] = [
-    (property_name, strategy_type, ETHANOL_PARAMS)
-        for strategy_type, dependencies_met in CHEMDB_STRATEGY_DEPENDENCIES_MET.items()
-            if dependencies_met
-                for property_name in strategy_type.queryable_properties()
-]
+def ethanol_params() -> ChemDBQueryParameters:
+    '''Fixed chemical query inputs for ethanol'''
+    return ChemDBQueryParameters(
+        identifier='CCO',
+        namespace='smiles',
+        keep_first_only=True,
+        allow_null_return=True, 
+    )
+
+def fixed_parameter_examples(chem_input : ChemDBQueryParameters) -> list[
+    tuple[str, type[ChemDBServiceQueryStrategy], ChemDBQueryParameters]
+]:
+    '''Examples which test all queryable properties against a fixed chemical input'''
+    return [
+        (property_name, strategy_type, chem_input)
+            for strategy_type, dependencies_met in CHEMDB_STRATEGY_DEPENDENCIES_MET.items()
+                if dependencies_met
+                    for property_name in strategy_type.queryable_properties()
+    ]
 
 # examples which test that many diverse inputs yield expected outputs
-VARIED_PARAMETER_EXAMPLES : list[
-    tuple[
-        str,
-        type[ChemDBServiceQueryStrategy],
-        ChemDBQueryParameters,
-        Any,
-    ] | ParameterSet
-] = [
-    # for NIH CACTUS
-    ( ## simple queries known to work for all services
-        'iupac_name',
-        NIHCACTUSQueryStrategy,
-        ChemDBQueryParameters( 
-            identifier='CCO',
-            namespace='smiles',
-            keep_first_only=True,
-            allow_null_return=False,
+def varied_parameter_examples() -> list[
+    tuple[str, type[ChemDBServiceQueryStrategy], ChemDBQueryParameters, Any] | ParameterSet
+]:
+    return [
+        # for NIH CACTUS
+        ( ## simple queries known to work for all services
+            'iupac_name',
+            NIHCACTUSQueryStrategy,
+            ChemDBQueryParameters( 
+                identifier='CCO',
+                namespace='smiles',
+                keep_first_only=True,
+                allow_null_return=False,
+            ),
+            'ethanol'
         ),
-        'ethanol'
-    ),
-    (
-        'inchi',
-        NIHCACTUSQueryStrategy,
-        ChemDBQueryParameters( 
-            identifier='N-methylformamide',
-            namespace='name',
-            keep_first_only=True,
-            allow_null_return=False,
+        (
+            'inchi',
+            NIHCACTUSQueryStrategy,
+            ChemDBQueryParameters( 
+                identifier='N-methylformamide',
+                namespace='name',
+                keep_first_only=True,
+                allow_null_return=False,
+            ),
+            'InChI=1/C2H5NO/c1-3-2-4/h2H,1H3,(H,3,4)/f/h3H',
         ),
-        'InChI=1/C2H5NO/c1-3-2-4/h2H,1H3,(H,3,4)/f/h3H',
-    ),
-    ( ## testing that different namespaces can be queried
-        'mw',
-        NIHCACTUSQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='benzophenone',
-            namespace='name', 
-            keep_first_only=True,
-            allow_null_return=False,
+        ( ## testing that different namespaces can be queried
+            'mw',
+            NIHCACTUSQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='benzophenone',
+                namespace='name', 
+                keep_first_only=True,
+                allow_null_return=False,
+            ),
+            '182.2214'
         ),
-        '182.2214'
-    ),
-    ( ## testing that returns with multiple data values work
-        'names',
-        NIHCACTUSQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='c1ccccc1-C(=S)S',
-            namespace='smiles', 
-            keep_first_only=False, 
-            allow_null_return=False,
+        ( ## testing that returns with multiple data values work
+            'names',
+            NIHCACTUSQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='c1ccccc1-C(=S)S',
+                namespace='smiles', 
+                keep_first_only=False, 
+                allow_null_return=False,
+            ),
+            ['Benzenecarbodithioic acid', '121-68-6', 'UPCMLD00WV-104', 'EINECS 204-491-4', 'Benzenecarbodithioic acid', 'Dithiobenzoic acid', 'NSC732246']
         ),
-        ['Benzenecarbodithioic acid', '121-68-6', 'UPCMLD00WV-104', 'EINECS 204-491-4', 'Benzenecarbodithioic acid', 'Dithiobenzoic acid', 'NSC732246']
-    ),
-    ( ## testing that enabling and disabling None returns is handled properly in both cases
-        'inchi',
-        NIHCACTUSQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='bogus-name', # this is obviously fake and should not return anything
-            namespace='name', 
-            keep_first_only=True,
-            allow_null_return=True,
+        ( ## testing that enabling and disabling None returns is handled properly in both cases
+            'inchi',
+            NIHCACTUSQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='bogus-name', # this is obviously fake and should not return anything
+                namespace='name', 
+                keep_first_only=True,
+                allow_null_return=True,
+            ),
+            None
         ),
-        None
-    ),
-    pytest.param( 
-        'inchi',
-        NIHCACTUSQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='bogus-name', # this is obviously fake and should not return anything
-            namespace='name', 
-            keep_first_only=True,
-            allow_null_return=False,
+        pytest.param( 
+            'inchi',
+            NIHCACTUSQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='bogus-name', # this is obviously fake and should not return anything
+                namespace='name', 
+                keep_first_only=True,
+                allow_null_return=False,
+            ),
+            None,
+            marks=pytest.mark.xfail(
+                raises=(NullPropertyResponse, ChemicalDataQueryFailed),
+                reason='Did not allow response to be NoneType',
+                strict=True,
+            )
         ),
-        None,
-        marks=pytest.mark.xfail(
-            raises=(NullPropertyResponse, ChemicalDataQueryFailed),
-            reason='Did not allow response to be NoneType',
-            strict=True,
-        )
-    ),
-    pytest.param( ## testing that invalid property values are caught before attempting a query
-        'in_no_way_a_valid_property', # this should not even be considered a valid property
-        NIHCACTUSQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='benophenone', 
-            namespace='name', 
-            keep_first_only=True,
-            allow_null_return=False,
+        pytest.param( ## testing that invalid property values are caught before attempting a query
+            'in_no_way_a_valid_property', # this should not even be considered a valid property
+            NIHCACTUSQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='benophenone', 
+                namespace='name', 
+                keep_first_only=True,
+                allow_null_return=False,
+            ),
+            None,
+            marks=pytest.mark.xfail(
+                raises=(InvalidPropertyError, ChemicalDataQueryFailed),
+                reason='Tried to query a property that does not exist',
+                strict=True,
+            )
         ),
-        None,
-        marks=pytest.mark.xfail(
-            raises=(InvalidPropertyError, ChemicalDataQueryFailed),
-            reason='Tried to query a property that does not exist',
-            strict=True,
-        )
-    ),
-    
-    # for PubChem
-    ( ## simple queries known to work for all services
-        'iupac_name',
-        PubChemQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='CCO',
-            namespace='smiles',
-            keep_first_only=True,
-            allow_null_return=False
+        
+        # for PubChem
+        ( ## simple queries known to work for all services
+            'iupac_name',
+            PubChemQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='CCO',
+                namespace='smiles',
+                keep_first_only=True,
+                allow_null_return=False
+            ),
+            'ethanol'
         ),
-        'ethanol'
-    ),
-    (
-        'inchi',
-        PubChemQueryStrategy,
-        ChemDBQueryParameters( 
-            identifier='N-methylformamide',
-            namespace='name',
-            keep_first_only=True,
-            allow_null_return=False,
+        (
+            'inchi',
+            PubChemQueryStrategy,
+            ChemDBQueryParameters( 
+                identifier='N-methylformamide',
+                namespace='name',
+                keep_first_only=True,
+                allow_null_return=False,
+            ),
+            'InChI=1S/C2H5NO/c1-3-2-4/h2H,1H3,(H,3,4)',
         ),
-        'InChI=1S/C2H5NO/c1-3-2-4/h2H,1H3,(H,3,4)',
-    ),
-    ( ## testing that different namespaces can be queried
-        'MolecularWeight',
-        PubChemQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='InChI=1S/C2H5NO/c1-3-2-4/h2H,1H3,(H,3,4)',
-            namespace='inchi', 
-            keep_first_only=True,
-            allow_null_return=False,
+        ( ## testing that different namespaces can be queried
+            'MolecularWeight',
+            PubChemQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='InChI=1S/C2H5NO/c1-3-2-4/h2H,1H3,(H,3,4)',
+                namespace='inchi', 
+                keep_first_only=True,
+                allow_null_return=False,
+            ),
+            '59.07',
         ),
-        '59.07',
-    ),
-    ( ## testing that returns with multiple data values work
-        'HeavyAtomCount',
-        PubChemQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='CCO', 
-            namespace='smiles', 
-            keep_first_only=False,
-            allow_null_return=False,
+        ( ## testing that returns with multiple data values work
+            'HeavyAtomCount',
+            PubChemQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='CCO', 
+                namespace='smiles', 
+                keep_first_only=False,
+                allow_null_return=False,
+            ),
+            [3], # note that this is wrapped in a list, as are all PubChem queries by deualt; I couldn't find a good example which returns more than one value like cirpy does
         ),
-        [3], # note that this is wrapped in a list, as are all PubChem queries by deualt; I couldn't find a good example which returns more than one value like cirpy does
-    ),
-    pytest.param( ## testing sending malformed queries to PubChem
-        'inchi',
-        PubChemQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='bogus-name', # this is obviously fake and should not return anything
-            namespace='smiles', 
-            keep_first_only=True,
-            allow_null_return=True,
+        pytest.param( ## testing sending malformed queries to PubChem
+            'inchi',
+            PubChemQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='bogus-name', # this is obviously fake and should not return anything
+                namespace='smiles', 
+                keep_first_only=True,
+                allow_null_return=True,
+            ),
+            None,
+            marks=pytest.mark.xfail(
+                raises=(ChemicalDataQueryFailed, HTTPError), # DEVNOTE: HTTPError here is absolutely necessary! Request should return HTTP error 400
+                reason='Invalid request sent to PubChem (queried a name as a SMILES string)',
+                strict=True,
+            )
         ),
-        None,
-        marks=pytest.mark.xfail(
-            raises=(ChemicalDataQueryFailed, HTTPError), # DEVNOTE: HTTPError here is absolutely necessary! Request should return HTTP error 400
-            reason='Invalid request sent to PubChem (queried a name as a SMILES string)',
-            strict=True,
-        )
-    ),
-    ( ## testing that enabling and disabling None returns is handled properly in both cases
-        'inchi',
-        PubChemQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='bogus-name', # this is obviously fake and should not return anything
-            namespace='name', 
-            keep_first_only=True,
-            allow_null_return=True,
+        ( ## testing that enabling and disabling None returns is handled properly in both cases
+            'inchi',
+            PubChemQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='bogus-name', # this is obviously fake and should not return anything
+                namespace='name', 
+                keep_first_only=True,
+                allow_null_return=True,
+            ),
+            None,
         ),
-        None,
-    ),
-    pytest.param(  
-        'inchi',
-        PubChemQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='bogus-name', # this is obviously fake and should not return anything
-            namespace='name', 
-            keep_first_only=True,
-            allow_null_return=False,
+        pytest.param(  
+            'inchi',
+            PubChemQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='bogus-name', # this is obviously fake and should not return anything
+                namespace='name', 
+                keep_first_only=True,
+                allow_null_return=False,
+            ),
+            None,
+            marks=pytest.mark.xfail(
+                raises=(NullPropertyResponse, ChemicalDataQueryFailed),
+                reason='Did not allow response to be NoneType',
+                strict=True,
+            )
         ),
-        None,
-        marks=pytest.mark.xfail(
-            raises=(NullPropertyResponse, ChemicalDataQueryFailed),
-            reason='Did not allow response to be NoneType',
-            strict=True,
-        )
-    ),
-    pytest.param( ## testing that invalid property values are caught before attempting a query
-        'in_no_way_a_valid_property', # this should not even be considered a valid property
-        PubChemQueryStrategy,
-        ChemDBQueryParameters(
-            identifier='benophenone', 
-            namespace='name', 
-            keep_first_only=True,
-            allow_null_return=False,
+        pytest.param( ## testing that invalid property values are caught before attempting a query
+            'in_no_way_a_valid_property', # this should not even be considered a valid property
+            PubChemQueryStrategy,
+            ChemDBQueryParameters(
+                identifier='benophenone', 
+                namespace='name', 
+                keep_first_only=True,
+                allow_null_return=False,
+            ),
+            None,
+            marks=pytest.mark.xfail(
+                raises=(InvalidPropertyError, ChemicalDataQueryFailed),
+                reason='Tried to query a property that does not exist',
+                strict=True,
+            )
         ),
-        None,
-        marks=pytest.mark.xfail(
-            raises=(InvalidPropertyError, ChemicalDataQueryFailed),
-            reason='Tried to query a property that does not exist',
-            strict=True,
-        )
-    ),
-]
+    ]
     
 class TestChemicalDatabaseServiceQueries:
     @pytest.mark.parametrize(
         'property_name,service_type,query_params',
-        FIXED_PARAMETER_EXAMPLES,
+        fixed_parameter_examples(ethanol_params()),
     )
     def test_queryable_properties(
         self,
@@ -322,7 +324,7 @@ class TestChemicalDatabaseServiceQueries:
 
     @pytest.mark.parametrize(
         'property_name,service_type,query_params,expected_property',
-        VARIED_PARAMETER_EXAMPLES,
+        varied_parameter_examples(),
     )
     def test_direct_service_property_query(
         self,
@@ -350,7 +352,7 @@ class TestChemicalDatabaseServiceQueries:
         
     @pytest.mark.parametrize(
         'property_name,service_type,query_params,expected_property',
-        VARIED_PARAMETER_EXAMPLES,
+        varied_parameter_examples(),
     )
     def test_get_chemical_property_wrapper(
         self,

--- a/polymerist/tests/smileslib/test_chemdbqueries.py
+++ b/polymerist/tests/smileslib/test_chemdbqueries.py
@@ -6,8 +6,9 @@ __email__ = 'timotej.bernat@colorado.edu'
 import pytest
 from _pytest.mark import ParameterSet
 
-from typing import Any, Optional
+from typing import Any, Callable, Optional, TypeVar
 from dataclasses import dataclass, asdict
+T = TypeVar('T')
 
 from requests import HTTPError
 
@@ -32,6 +33,19 @@ TIMEOUT_ERR_CODES : set[int] = {
     503, # MAINTENANCE OR OVERLOAD
     504, # REQUEST TIMEOUT
 }
+def skip_on_server_errors(func : Callable[[], T]) -> T:
+    '''Boilerplate for skipping surrounding tests on server failures upon query'''
+    try:
+        output = func()
+    except HTTPError as exc:
+        http_err_code : Optional[int] = getattr(exc, 'code', None)
+        if http_err_code in TIMEOUT_ERR_CODES:
+            pytest.skip('Overloaded server or request denied; test will be inconclusive')
+        else:
+            raise exc
+    else:
+        return output
+
 CHEMDB_STRATEGY_ONLINE : dict[type[ChemDBServiceQueryStrategy], bool] = {}
 CHEMDB_STRATEGY_DEPENDENCIES_MET : dict[type[ChemDBServiceQueryStrategy], bool] = {}
 for ChemDBStrategy in ChemDBServiceQueryStrategy.__subclasses__(): # dynamically determine criteria for which services should be tested
@@ -311,16 +325,14 @@ class TestChemicalDatabaseServiceQueries:
         '''Test that the properties each service type lists as queryable do indeed return valid results'''
         skip_pytest_on_invalid_service(service_type=service_type)
         service = service_type()
-        
-        try:
-            # no assert, simply checking that this doesn't raise Exception
-            _ = service.get_property(property_name=property_name, **asdict(query_params)) 
-        except HTTPError as exc:
-            http_err_code : Optional[int] = getattr(exc, 'code', None)
-            if http_err_code in TIMEOUT_ERR_CODES:
-                pytest.skip('Overloaded server or request denied; test will be inconclusive')
-            else:
-                raise exc
+
+        # no assert, simply checking that this doesn't raise uncaught Exception
+        _ = skip_on_server_errors(
+            lambda : service.get_property(
+                property_name=property_name,
+                **asdict(query_params)
+            ) 
+        )
 
     @pytest.mark.parametrize(
         'property_name,service_type,query_params,expected_property',
@@ -336,19 +348,14 @@ class TestChemicalDatabaseServiceQueries:
         '''Test if a chemical database query through a given service is executed completely and returns the expected result'''
         skip_pytest_on_invalid_service(service_type=service_type)
         service = service_type()
-        try:
-            actual_property = service.get_property(
+
+        actual_property = skip_on_server_errors(
+            lambda : service.get_property(
                 property_name=property_name,
                 **asdict(query_params),
             )
-        except HTTPError as exc:
-            http_err_code : Optional[int] = getattr(exc, 'code', None)
-            if http_err_code in TIMEOUT_ERR_CODES:
-                pytest.skip('Overloaded server or request denied; test will be inconclusive')
-            else:
-                raise exc
-        else:
-            assert actual_property == expected_property
+        )
+        assert actual_property == expected_property
         
     @pytest.mark.parametrize(
         'property_name,service_type,query_params,expected_property',
@@ -363,19 +370,14 @@ class TestChemicalDatabaseServiceQueries:
     ) -> None:
         '''Test that requests filtered through the get_chemical_properties() strategy wrapper are executed faithfully'''
         skip_pytest_on_invalid_service(service_type=service_type)
-        try:
-            actual_property = get_chemical_property(
+
+        actual_property = skip_on_server_errors(
+            lambda : get_chemical_property(
                 property_name,
                 **asdict(query_params),
                 services=[service_type],
                 fail_quietly=False, # CRUCIAL that fail_quietly be False; rely on exceptions to match with xfails
             )
-        except HTTPError as exc:
-            http_err_code : Optional[int] = getattr(exc, 'code', None)
-            if http_err_code in TIMEOUT_ERR_CODES:
-                pytest.skip('Overloaded server or request denied; test will be inconclusive')
-            else:
-                raise exc
-        else:
-            assert actual_property == expected_property 
+        )
+        assert actual_property == expected_property
     


### PR DESCRIPTION
## Description
Patches to prevent CI failures due external HTTP server errors (i.e. not in-code faults) and declutter debug

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Remove debug `print()` statements from all code
  - [x] Add [HTTP 502 (bad gateway proxy)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/502) to skipped request errors when testing chemical database queries

## Status
- [ ] Pass CI tests
- [ ] Ready to go